### PR TITLE
changes after linting

### DIFF
--- a/examples/static-website-with-domain-ssl/README.md
+++ b/examples/static-website-with-domain-ssl/README.md
@@ -75,17 +75,17 @@ This option provisions an ssl certificate and a redirect from http to https traf
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| project | n/a | `string` | n/a | yes |
-| domain | your domain name (ex. yourdomain.com)| `string` | n/a | yes |
+| domain | Zone domain | `string` | n/a | yes |
+| project | The ID of the project to create the bucket in. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| name-servers | the list of name servers from Cloud DNS to add to your domain registry |
-| load-balancer-ip | ip of the public site |
-| bucket-name | name of the cloud storage bucket |
-| bucket-url | url of the cloud storage bucket |
+| bucket-name | n/a |
+| bucket-url | n/a |
+| loadbalancer-ip | n/a |
+| name-servers | n/a |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ​

--- a/examples/static-website-with-no-domain/README.md
+++ b/examples/static-website-with-no-domain/README.md
@@ -70,15 +70,15 @@ for production use.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| project | n/a | `string` | n/a | yes |
+| project | The ID of the project to create the bucket in. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| load-balancer-ip | ip of the public site |
-| bucket-name | name of the cloud storage bucket |
-| bucket-url | url of the cloud storage bucket |
+| bucket-name | n/a |
+| bucket-url | n/a |
+| loadbalancer-ip | n/a |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ​

--- a/modules/backend_bucket/versions.tf
+++ b/modules/backend_bucket/versions.tf
@@ -20,11 +20,11 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.53"
+      version = ">= 3.53, < 5.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.53"
+      version = ">= 3.53, < 5.0"
     }
   }
 


### PR DESCRIPTION
Adds functionality to host static website content behind a HTTP lb using a Cloud Storage Bucket and CDN. Also includes 2 examples, one just using an IP over http and another using a custom domain, https, and ssl.